### PR TITLE
Properly pass :condition

### DIFF
--- a/app/controllers/bulk_time_entries_controller.rb
+++ b/app/controllers/bulk_time_entries_controller.rb
@@ -67,7 +67,7 @@ class BulkTimeEntriesController < ApplicationController
   
   def load_allowed_projects
     @projects = User.current.projects.find(:all,
-      Project.allowed_to_condition(User.current, :log_time))
+      :conditions => Project.allowed_to_condition(User.current, :log_time))
   end
 
   def load_first_project


### PR DESCRIPTION
Rather surprisingly, find(:all, "string") just silently ignores the given string, which explains why this has gone
unnoticed.
